### PR TITLE
Run only most recent day by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,10 @@
 # It is not intended for manual editing.
 [[package]]
 name = "aoc-main"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "attohttpc",
+ "chrono",
  "clap 3.0.0-beta.2",
  "colored",
  "criterion",
@@ -133,6 +134,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
 
 [[package]]
 name = "clap"
@@ -367,7 +381,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -505,6 +519,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -907,6 +931,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1036,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,7 +5,6 @@ name = "aoc-main"
 version = "0.3.0"
 dependencies = [
  "attohttpc",
- "chrono",
  "clap 3.0.0-beta.2",
  "colored",
  "criterion",
@@ -134,19 +133,6 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
-
-[[package]]
-name = "chrono"
-version = "0.4.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
-dependencies = [
- "libc",
- "num-integer",
- "num-traits",
- "time",
- "winapi",
-]
 
 [[package]]
 name = "clap"
@@ -381,7 +367,7 @@ checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -519,16 +505,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -931,17 +907,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tinytemplate"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1036,12 +1001,6 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ bench = ["criterion"]
 
 [dependencies]
 attohttpc = { version = "0.16.0", default_features = false, features = ["tls"] }
-chrono = "0.4"
 clap = { version = "3.0.0-beta.2", default_features = false, features = ["std"] }
 colored = "2.0.0"
 dirs = "3.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bench = ["criterion"]
 
 [dependencies]
 attohttpc = { version = "0.16.0", default_features = false, features = ["tls"] }
+chrono = "0.4"
 clap = { version = "3.0.0-beta.2", default_features = false, features = ["std"] }
 colored = "2.0.0"
 dirs = "3.0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,19 +90,18 @@ macro_rules! base_main {
                             .into_iter()
                             .filter(|day| days.contains(&format!("day{}", day).as_str()))
                             .collect()
+                    } else if opt.is_present("all") {
+                        parse!(extract_day {}; $( $tail )*)
+                            .iter()
+                            .map(|s| &s[3..])
+                            .collect()
                     } else {
-                        if opt.is_present("all") {
-                            parse!(extract_day {}; $( $tail )*)
-                                .iter()
-                                .map(|s| &s[3..])
-                                .collect()
-                        } else {
-                            vec![parse!(extract_day {}; $( $tail )*)
-                                .iter()
-                                .map(|s| &s[3..])
-                                .last()
-                                .expect("No day implemenations found")]
-                        }
+                        // Get most recent day, assuming the days are sorted
+                        vec![parse!(extract_day {}; $( $tail )*)
+                            .iter()
+                            .map(|s| &s[3..])
+                            .last()
+                            .expect("No day implemenations found")]
                     }
                 };
 


### PR DESCRIPTION
This copies the default behavior from cargo-aoc, where only the most recent day is run by default rather than all the days at once, allowing this to be overridden with a new `--all` flag. This brings in a new (fairly minimal) dependency on `chrono`, but can probably be rewritten without that.