### PR TITLE
Change dimmed to light_black

### DIFF
--- a/src/parse/gen_run.rs
+++ b/src/parse/gen_run.rs
@@ -130,7 +130,7 @@ macro_rules! skip_sol {
 
         println!(
             "  - {}",
-            Line::new(stringify!($solution)).with_state("skipped".dimmed())
+            Line::new(stringify!($solution)).with_state("skipped".bright_black())
         );
     }};
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -79,13 +79,13 @@ impl fmt::Display for Line {
             .map(|duration| format!(" ({:.2?})", duration))
             .unwrap_or_else(String::new);
 
-        write!(f, "{}{}", self.text, duration.dimmed())?;
+        write!(f, "{}{}", self.text, duration.bright_black())?;
 
         if let Some(state) = &self.state {
             let width = self.text.chars().count() + 1 + duration.chars().count();
             let dots = display_width - min(display_width - 5, width) - 2;
             let dots: String = iter::repeat('.').take(dots).collect();
-            write!(f, " {}", dots.dimmed())?;
+            write!(f, " {}", dots.bright_black())?;
 
             if state.contains('\n') {
                 for line in state.trim_matches('\n').lines() {


### PR DESCRIPTION
Currently when using the colored crate in the vscode terminal on windows 10 .dimmed() doesn't change the color. .light_black() is very close to the same color and work in the vscode terminal on windows 10, it also works correctly in the new Windows Terminal, but dimmed also worked there.

Closes #13 