### PR TITLE
Borrowed_gen_data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "aoc-main"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "attohttpc",
  "clap 4.0.29",

--- a/src/parse/gen_run.rs
+++ b/src/parse/gen_run.rs
@@ -29,7 +29,7 @@ macro_rules! run_day {
                 $( $crate::run_sol!($day, &input, $sol); )+
             } else {
                 $( $crate::skip_sol!($sol); )+
-            }
+            };
         }
     }}
 }


### PR DESCRIPTION
Without this semicolon attempting to return an impl '_ + Iterator<...> + Clone from a generator results in an error about the temp borrow created in run_gen. The ; causes the temp to be dropped before the outer scope that owns data exits and runs its own drops.