### PR TITLE
[Visual] Add colors to the output of times depending on the speed

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,13 @@ pub fn args(year: u16) -> Command {
                 .conflicts_with("days")
                 .help("Run all days"),
         )
+        .arg(
+            Arg::new("color")
+                .short('c')
+                .long("color")
+                .action(ArgAction::SetTrue)
+                .help("Enable colored timings"),
+        )
 }
 
 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,9 +57,9 @@ pub fn args(year: u16) -> Command {
         .arg(
             Arg::new("color")
                 .short('c')
-                .long("color")
+                .long("no-color")
                 .action(ArgAction::SetTrue)
-                .help("Enable colored timings"),
+                .help("Disable colored timings"),
         )
 }
 

--- a/src/parse/gen_run.rs
+++ b/src/parse/gen_run.rs
@@ -52,7 +52,7 @@ macro_rules! run_gen {
             "  - {}",
             Line::new("generator")
                 .with_duration(elapsed)
-                .with_duration_color($opt.get_flag("color"))
+                .disable_duration_color($opt.get_flag("color"))
         );
         Some(input)
     }};
@@ -72,7 +72,7 @@ macro_rules! run_gen {
                     "  - {}",
                     Line::new("generator")
                         .with_duration(elapsed)
-                        .with_duration_color($opt.get_flag("color"))
+                        .disable_duration_color($opt.get_flag("color"))
                 );
                 Some(input)
             }
@@ -81,7 +81,7 @@ macro_rules! run_gen {
                     "  - {}",
                     Line::new("generator")
                         .with_duration(elapsed)
-                        .with_duration_color($opt.get_flag("color"))
+                        .disable_duration_color($opt.get_flag("color"))
                         .with_state(msg.red())
                 );
                 None
@@ -105,7 +105,7 @@ macro_rules! run_sol {
             "  - {}",
             Line::new(stringify!($solution))
                 .with_duration(elapsed)
-                .with_duration_color($opt.get_flag("color"))
+                .disable_duration_color($opt.get_flag("color"))
                 .with_state(format!("{}", response).normal())
         );
     }};
@@ -120,7 +120,7 @@ macro_rules! run_sol {
         let elapsed = start.elapsed();
         let line = Line::new(stringify!($solution))
             .with_duration(elapsed)
-            .with_duration_color($opt.get_flag("color"));
+            .disable_duration_color($opt.get_flag("color"));
 
         println!(
             "  - {}",

--- a/src/parse/gen_run.rs
+++ b/src/parse/gen_run.rs
@@ -25,8 +25,8 @@ macro_rules! run_day {
                 }
             };
 
-            if let Some(input) = $crate::run_gen!($day, &data, $gen) {
-                $( $crate::run_sol!($day, &input, $sol); )+
+            if let Some(input) = $crate::run_gen!($day, &data, $opt, $gen) {
+                $( $crate::run_sol!($day, &input, $opt, $sol); )+
             } else {
                 $( $crate::skip_sol!($sol); )+
             }
@@ -37,23 +37,28 @@ macro_rules! run_day {
 #[macro_export]
 macro_rules! run_gen {
     // No generator is needed: default behavior is to just pass input &str
-    ( $day: ident, $data: expr, { gen_default } ) => {{
+    ( $day: ident, $data: expr, $opt: expr, { gen_default } ) => {{
         Some($data)
     }};
 
     // Run generator
-    ( $day: ident, $data: expr, { gen $generator: ident } ) => {{
+    ( $day: ident, $data: expr, $opt: expr, { gen $generator: ident }) => {{
         use $crate::utils::Line;
 
         let start = Instant::now();
         let input = $day::$generator($data);
         let elapsed = start.elapsed();
-        println!("  - {}", Line::new("generator").with_duration(elapsed));
+        println!(
+            "  - {}",
+            Line::new("generator")
+                .with_duration(elapsed)
+                .with_duration_color($opt.get_flag("color"))
+        );
         Some(input)
     }};
 
     // Run fallible generator
-    ( $day: ident, $data: expr, { gen_fallible $generator: ident } ) => {{
+    ( $day: ident, $data: expr, $opt: expr, { gen_fallible $generator: ident }) => {{
         use $crate::colored::*;
         use $crate::utils::{Line, TryUnwrap};
 
@@ -63,7 +68,12 @@ macro_rules! run_gen {
 
         match result.try_unwrap() {
             Ok(input) => {
-                println!("  - {}", Line::new("generator").with_duration(elapsed));
+                println!(
+                    "  - {}",
+                    Line::new("generator")
+                        .with_duration(elapsed)
+                        .with_duration_color($opt.get_flag("color"))
+                );
                 Some(input)
             }
             Err(msg) => {
@@ -71,6 +81,7 @@ macro_rules! run_gen {
                     "  - {}",
                     Line::new("generator")
                         .with_duration(elapsed)
+                        .with_duration_color($opt.get_flag("color"))
                         .with_state(msg.red())
                 );
                 None
@@ -82,7 +93,7 @@ macro_rules! run_gen {
 #[macro_export]
 macro_rules! run_sol {
     // Run solution
-    ( $day: ident, $input: expr, { sol $solution: ident } ) => {{
+    ( $day: ident, $input: expr, $opt: expr, { sol $solution: ident } ) => {{
         use $crate::colored::*;
         use $crate::utils::Line;
 
@@ -94,19 +105,22 @@ macro_rules! run_sol {
             "  - {}",
             Line::new(stringify!($solution))
                 .with_duration(elapsed)
+                .with_duration_color($opt.get_flag("color"))
                 .with_state(format!("{}", response).normal())
         );
     }};
 
     // Run fallible solution
-    ( $day: ident, $input: expr, { sol_fallible $solution: ident } ) => {{
+    ( $day: ident, $input: expr, $opt: expr, { sol_fallible $solution: ident } ) => {{
         use $crate::colored::*;
         use $crate::utils::{Line, TryUnwrap};
 
         let start = Instant::now();
         let response = $day::$solution($input);
         let elapsed = start.elapsed();
-        let line = Line::new(stringify!($solution)).with_duration(elapsed);
+        let line = Line::new(stringify!($solution))
+            .with_duration(elapsed)
+            .with_duration_color($opt.get_flag("color"));
 
         println!(
             "  - {}",

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -87,10 +87,10 @@ impl fmt::Display for Line {
 
         let duration = match self.duration {
             _ if !self.duration_color => duration.bright_black(),
-            Some(ns) if Duration::from_nanos(1000) > ns => duration.bright_magenta(),
-            Some(us) if Duration::from_micros(1000) > us => duration.green(),
-            Some(ms) if Duration::from_millis(1000) > ms => duration.bright_yellow(),
-            Some(s) if Duration::from_secs(60) > s => duration.bright_red(),
+            Some(d) if d < Duration::from_nanos(1000) => duration.bright_magenta(),
+            Some(d) if d < Duration::from_micros(1000) => duration.green(),
+            Some(d) if d < Duration::from_millis(1000) => duration.bright_yellow(),
+            Some(d) if d < Duration::from_secs(60) => duration.bright_red(),
             _ => duration.bright_black(),
         };
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,7 +46,7 @@ const DEFAULT_WIDTH: usize = 30;
 pub struct Line {
     text: String,
     duration: Option<Duration>,
-    duration_color: bool,
+    disable_duration_color: bool,
     state: Option<ColoredString>,
 }
 
@@ -55,7 +55,7 @@ impl Line {
         Self {
             text: text.into(),
             duration: None,
-            duration_color: false,
+            disable_duration_color: false,
             state: None,
         }
     }
@@ -70,8 +70,8 @@ impl Line {
         self
     }
 
-    pub fn with_duration_color(mut self, color: bool) -> Self {
-        self.duration_color = color;
+    pub fn disable_duration_color(mut self, disable: bool) -> Self {
+        self.disable_duration_color = disable;
         self
     }
 }
@@ -86,7 +86,7 @@ impl fmt::Display for Line {
             .unwrap_or_else(String::new);
 
         let duration = match self.duration {
-            _ if !self.duration_color => duration.bright_black(),
+            _ if self.disable_duration_color => duration.bright_black(),
             Some(d) if d < Duration::from_nanos(1000) => duration.bright_magenta(),
             Some(d) if d < Duration::from_micros(1000) => duration.green(),
             Some(d) if d < Duration::from_millis(1000) => duration.bright_yellow(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -46,6 +46,7 @@ const DEFAULT_WIDTH: usize = 30;
 pub struct Line {
     text: String,
     duration: Option<Duration>,
+    duration_color: bool,
     state: Option<ColoredString>,
 }
 
@@ -54,6 +55,7 @@ impl Line {
         Self {
             text: text.into(),
             duration: None,
+            duration_color: false,
             state: None,
         }
     }
@@ -65,6 +67,11 @@ impl Line {
 
     pub fn with_state(mut self, state: impl Into<ColoredString>) -> Self {
         self.state = Some(state.into());
+        self
+    }
+
+    pub fn with_duration_color(mut self, color: bool) -> Self {
+        self.duration_color = color;
         self
     }
 }
@@ -79,6 +86,7 @@ impl fmt::Display for Line {
             .unwrap_or_else(String::new);
 
         let duration = match self.duration {
+            _ if !self.duration_color => duration.bright_black(),
             Some(ns) if Duration::from_nanos(1000) > ns => duration.bright_magenta(),
             Some(us) if Duration::from_micros(1000) > us => duration.green(),
             Some(ms) if Duration::from_millis(1000) > ms => duration.bright_yellow(),

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -78,7 +78,15 @@ impl fmt::Display for Line {
             .map(|duration| format!(" ({:.2?})", duration))
             .unwrap_or_else(String::new);
 
-        write!(f, "{}{}", self.text, duration.bright_black())?;
+        let duration = match self.duration {
+            Some(ns) if Duration::from_nanos(1000) > ns => duration.bright_magenta(),
+            Some(us) if Duration::from_micros(1000) > us => duration.green(),
+            Some(ms) if Duration::from_millis(1000) > ms => duration.bright_yellow(),
+            Some(s) if Duration::from_secs(60) > s => duration.bright_red(),
+            _ => duration.bright_black(),
+        };
+
+        write!(f, "{}{}", self.text, duration)?;
 
         if let Some(state) = &self.state {
             let width = self.text.chars().count() + 1 + duration.chars().count();


### PR DESCRIPTION
_Don't know if this is something you'd like in your project, but I enjoy it. Feel free to close or critique, this is my first Rust PR._

This changes the color of the times outputted when running depending on the speed, to make it easiers to spot outliers and possible slow implementations. Since _slow_ is subjective this feature disabled by default and I've added a command line flag `-c` or `--color` to enable the coloring.

Here are two screenshot with fast and slow solutions to illustrate the colors.
![2022-12-14_15:58:33](https://user-images.githubusercontent.com/39232833/207646252-5262f34f-b9e0-4c2b-b75d-3230d1e19b03.png)
![2022-12-14_15:57:58](https://user-images.githubusercontent.com/39232833/207646260-e120acf2-bdf1-4051-8b1d-6e3d47c124e9.png)

